### PR TITLE
Fix: URL Fragments in README

### DIFF
--- a/openapi/components/README.md
+++ b/openapi/components/README.md
@@ -1,13 +1,13 @@
 # Reusable components
 
 * You can create the following folders here:
-  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#schemaObject)
-  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#responseObject)
-  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#parameterObject)
-  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#exampleObject)
-  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#headerObject)
-  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#requestBodyObject)
-  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#linkObject)
-  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#callbackObject)
-  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#securitySchemeObject)
+  - `schemas` - reusable [Schema Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#schema-object)
+  - `responses` - reusable [Response Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#response-object)
+  - `parameters` - reusable [Parameter Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#parameter-object)
+  - `examples` - reusable [Example Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#example-object)
+  - `headers` - reusable [Header Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#header-object)
+  - `requestBodies` - reusable [Request Body Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#request-body-object)
+  - `links` - reusable [Link Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#link-object)
+  - `callbacks` - reusable [Callback Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#callback-object)
+  - `securitySchemes` - reusable [Security Scheme Objects](https://github.com/OAI/OpenAPI-Specification/blob/main/versions/3.0.2.md#security-scheme-object)
 * Filename of files inside the folders represent component name, e.g. `Customer.yaml`


### PR DESCRIPTION
## What/Why/How?

I updated the URL fragments in the README to work properly because they were not functioning as expected.

## Reference

## Testing

## Screenshots (optional)

## Check yourself

- [ ] Code is linted
- [ ] Tested
- [ ] All new/updated code is covered with tests

## Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines
